### PR TITLE
Added WS endpoint for stats - exposes data already gathered in main loop

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -12,6 +12,7 @@ use crate::routes::events_ws::events_ws;
 use crate::routes::exec::{exec_once_handler, exec_ws_handler};
 use crate::routes::metrics::metrics_handler;
 use crate::routes::read_file::read_file_handler;
+use crate::routes::stats_ws::stats_ws;
 use crate::routes::write_file::write_file_handler;
 use crate::state::AppState;
 
@@ -26,7 +27,8 @@ use crate::state::AppState;
         crate::routes::exec::exec_once_handler,
         crate::routes::write_file::write_file_handler,
         crate::routes::read_file::read_file_handler,
-        crate::routes::events_ws::events_ws
+        crate::routes::events_ws::events_ws,
+        crate::routes::stats_ws::stats_ws
     )
 )]
 struct ApiDoc;
@@ -43,6 +45,7 @@ pub(crate) fn build_router(app: Arc<AppState>) -> Router {
         .route("/containers/{id}/read-file", post(read_file_handler))
         .route("/metrics", get(metrics_handler))
         .route("/events/ws", get(events_ws))
+        .route("/stats/ws", get(stats_ws))
         .with_state(app)
         .merge(
             utoipa_swagger_ui::SwaggerUi::new("/swagger")

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -6,4 +6,5 @@ pub mod events_ws;
 pub mod exec;
 pub mod metrics;
 pub mod read_file;
+pub mod stats_ws;
 pub mod write_file;

--- a/src/routes/stats_ws.rs
+++ b/src/routes/stats_ws.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{ws::Message, State, WebSocketUpgrade},
+    response::IntoResponse,
+};
+
+use crate::state::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/stats/ws",
+    description = "Exposes container stats via WS",
+    responses(
+        (status = 101, description = "WebSocket upgrade initiated")
+    ),
+    tag = "Streaming"
+)]
+pub async fn stats_ws(State(app): State<Arc<AppState>>, ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(move |mut socket| async move {
+        let mut rx = app.stats_tx.subscribe();
+        while let Ok(ev) = rx.recv().await {
+            // Ignore errors if client closed
+            let _ = socket.send(Message::Text(ev.to_string().into())).await;
+        }
+    })
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,7 @@ pub struct CpuSnapshot {
 pub struct AppState {
     pub(crate) docker: Docker,
     pub(crate) events_tx: broadcast::Sender<serde_json::Value>,
+    pub(crate) stats_tx: broadcast::Sender<serde_json::Value>,
     pub(crate) metric_registry: MetricRegistry,
     pub(crate) cpu_snapshots: RwLock<HashMap<String, CpuSnapshot>>,
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::state::AppState;
+
+#[derive(Debug, Serialize)]
+struct Stats {
+    cpu_avg: Option<f64>,
+    max_mem: Option<u64>,
+}
+
+pub fn push_stats_to_ws_clients(app: Arc<AppState>) {
+    let mut container_stats: BTreeMap<String, Stats> = BTreeMap::default();
+
+    for entry in app.metric_registry.cpu.iter() {
+        let id = entry.key();
+        let cpu_avg = app.metric_registry.cpu_avg(id, Duration::from_secs(10));
+        let max_mem = app.metric_registry.mem_max(id, Duration::from_secs(10));
+
+        container_stats.insert(id.clone(), Stats { cpu_avg, max_mem });
+    }
+
+    match serde_json::to_value(&container_stats) {
+        Ok(serialized) => {
+            let _ = app.stats_tx.send(serialized);
+        }
+        Err(e) => {
+            tracing::warn!("Failed to serialize container stats: {}", e);
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new WebSocket endpoint (`/stats/ws`) for real-time streaming of container statistics to clients.
  * Added periodic broadcasting of container CPU and memory statistics to connected WebSocket clients.

* **Documentation**
  * Updated API documentation to include the new `/stats/ws` streaming endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->